### PR TITLE
纠正一个错误的描述。

### DIFF
--- a/content/chapter2/chapter2-4-chinese.md
+++ b/content/chapter2/chapter2-4-chinese.md
@@ -95,4 +95,5 @@ void insert_sorted(C &v, const T &item)
 }
 ```
 
-当我们要将`std::vector`类型转换为其他类型时，需要注意的是并不是所有容器都支持`std::sort`。该函数所对应的算法需要容器为可随机访问容器，例如`std::list`就无法进行排序。
+当我们要将`std::vector`类型转换为其他类型时，需要注意的是并不是所有容器都支持`std::sort`。该函数所对应的算法需要容器为可随机访问容器，例如`std::list`就无法用`std::sort`进行排序。
+不过，`std::list`可以使用成员函数`sort`进行排序。


### PR DESCRIPTION
std::sort 确实不可以对 std::list 进行排序，但不代表 list 不可以排序，实际上 std::list 也提供了成员函数 sort()，可以对 list 进行排序。